### PR TITLE
献立に関するモデルの構築

### DIFF
--- a/lib/model/dish/dish_model.dart
+++ b/lib/model/dish/dish_model.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'package:hakondate_v2/model/foodstuff/foodstuff_model.dart';
+
+part 'dish_model.g.dart';
+
+@JsonSerializable()
+class DishModel {
+  DishModel({
+    required this.name,
+    required this.foodstuffs,
+    this.category
+  });
+
+  factory DishModel.fromJson(Map<String, dynamic> json) =>
+      _$DishModelFromJson(json);
+  Map<String, dynamic> toJson() => _$DishModelToJson(this);
+
+  final String name;                      // 料理名
+  final List<FoodstuffModel> foodstuffs;  // 食材
+  final String? category;                 // 分類
+}

--- a/lib/model/dish/dish_model.g.dart
+++ b/lib/model/dish/dish_model.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'dish_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DishModel _$DishModelFromJson(Map<String, dynamic> json) {
+  return DishModel(
+    name: json['name'] as String,
+    foodstuffs: (json['foodstuffs'] as List<dynamic>)
+        .map((e) => FoodstuffModel.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    category: json['category'] as String?,
+  );
+}
+
+Map<String, dynamic> _$DishModelToJson(DishModel instance) => <String, dynamic>{
+      'name': instance.name,
+      'foodstuffs': instance.foodstuffs,
+      'category': instance.category,
+    };

--- a/lib/model/foodstuff/foodstuff_model.dart
+++ b/lib/model/foodstuff/foodstuff_model.dart
@@ -1,0 +1,27 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'package:hakondate_v2/model/nutrients/nutrients_model.dart';
+import 'package:hakondate_v2/model/quantity/quantity_model.dart';
+
+part 'foodstuff_model.g.dart';
+
+@JsonSerializable()
+class FoodstuffModel {
+  FoodstuffModel({
+    required this.name,
+    required this.quantity,
+    required this.nutrients,
+    this.isAllergy = false,
+    this.isHeat = false
+  });
+
+  factory FoodstuffModel.fromJson(Map<String, dynamic> json) =>
+      _$FoodstuffModelFromJson(json);
+  Map<String, dynamic> toJson() => _$FoodstuffModelToJson(this);
+
+  final String name;              // 食材名
+  final QuantityModel quantity;   // 分量
+  final NutrientsModel nutrients; // 栄養素
+  final bool isAllergy;           // アレルギー食品
+  final bool isHeat;              // 熱加工食品
+}

--- a/lib/model/foodstuff/foodstuff_model.g.dart
+++ b/lib/model/foodstuff/foodstuff_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'foodstuff_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FoodstuffModel _$FoodstuffModelFromJson(Map<String, dynamic> json) {
+  return FoodstuffModel(
+    name: json['name'] as String,
+    quantity: QuantityModel.fromJson(json['quantity'] as Map<String, dynamic>),
+    nutrients:
+        NutrientsModel.fromJson(json['nutrients'] as Map<String, dynamic>),
+    isAllergy: json['isAllergy'] as bool,
+    isHeat: json['isHeat'] as bool,
+  );
+}
+
+Map<String, dynamic> _$FoodstuffModelToJson(FoodstuffModel instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'quantity': instance.quantity,
+      'nutrients': instance.nutrients,
+      'isAllergy': instance.isAllergy,
+      'isHeat': instance.isHeat,
+    };

--- a/lib/model/menu/menu_model.dart
+++ b/lib/model/menu/menu_model.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'package:hakondate_v2/model/dish/dish_model.dart';
+import 'package:hakondate_v2/model/school/school_model.dart';
+
+part 'menu_model.g.dart';
+
+@JsonSerializable()
+class MenuModel {
+  MenuModel({
+    required this.day,
+    required this.school,
+    required this.dishes
+  });
+
+  factory MenuModel.fromJson(Map<String, dynamic> json) =>
+      _$MenuModelFromJson(json);
+  Map<String, dynamic> toJson() => _$MenuModelToJson(this);
+
+  final DateTime day;           // 日付
+  final SchoolModel school;     // 学校
+  final List<DishModel> dishes; // 料理
+}

--- a/lib/model/menu/menu_model.g.dart
+++ b/lib/model/menu/menu_model.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'menu_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MenuModel _$MenuModelFromJson(Map<String, dynamic> json) {
+  return MenuModel(
+    day: DateTime.parse(json['day'] as String),
+    school: SchoolModel.fromJson(json['school'] as Map<String, dynamic>),
+    dishes: (json['dishes'] as List<dynamic>)
+        .map((e) => DishModel.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+Map<String, dynamic> _$MenuModelToJson(MenuModel instance) => <String, dynamic>{
+      'day': instance.day.toIso8601String(),
+      'school': instance.school,
+      'dishes': instance.dishes,
+    };

--- a/lib/model/nutrients/nutrients_model.dart
+++ b/lib/model/nutrients/nutrients_model.dart
@@ -1,0 +1,45 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'nutrients_model.g.dart';
+
+@JsonSerializable()
+class NutrientsModel {
+  NutrientsModel({
+    this.energy = 0.0,
+    this.protein = 0.0,
+    this.lipid = 0.0,
+    this.carbohydrate = 0.0,
+    this.sodium = 0.0,
+    this.calcium = 0.0,
+    this.magnesium = 0.0,
+    this.iron = 0.0,
+    this.zinc = 0.0,
+    this.retinol = 0.0,
+    this.vitaminB1 = 0.0,
+    this.vitaminB2 = 0.0,
+    this.vitaminC = 0.0,
+    this.dietaryFiber = 0.0,
+    this.salt = 0.0
+  });
+
+  factory NutrientsModel.fromJson(Map<String, dynamic> json) =>
+      _$NutrientsModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NutrientsModelToJson(this);
+
+  final double energy;        // エネルギー
+  final double protein;       // タンパク質
+  final double lipid;         // 脂質
+  final double carbohydrate;  // 炭水化物
+  final double sodium;        // ナトリウム
+  final double calcium;       // カルシウム
+  final double magnesium;     // マグネシウム
+  final double iron;          // 鉄分
+  final double zinc;          // 亜鉛
+  final double retinol;       // レチノール活性当量(ビタミンA)
+  final double vitaminB1;     // ビタミンB1
+  final double vitaminB2;     // ビタミンB2
+  final double vitaminC;      // ビタミンC
+  final double dietaryFiber;  // 食物繊維
+  final double salt;          // 食塩相当量
+}

--- a/lib/model/nutrients/nutrients_model.g.dart
+++ b/lib/model/nutrients/nutrients_model.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nutrients_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+NutrientsModel _$NutrientsModelFromJson(Map<String, dynamic> json) {
+  return NutrientsModel(
+    energy: (json['energy'] as num).toDouble(),
+    protein: (json['protein'] as num).toDouble(),
+    lipid: (json['lipid'] as num).toDouble(),
+    carbohydrate: (json['carbohydrate'] as num).toDouble(),
+    sodium: (json['sodium'] as num).toDouble(),
+    calcium: (json['calcium'] as num).toDouble(),
+    magnesium: (json['magnesium'] as num).toDouble(),
+    iron: (json['iron'] as num).toDouble(),
+    zinc: (json['zinc'] as num).toDouble(),
+    retinol: (json['retinol'] as num).toDouble(),
+    vitaminB1: (json['vitaminB1'] as num).toDouble(),
+    vitaminB2: (json['vitaminB2'] as num).toDouble(),
+    vitaminC: (json['vitaminC'] as num).toDouble(),
+    dietaryFiber: (json['dietaryFiber'] as num).toDouble(),
+    salt: (json['salt'] as num).toDouble(),
+  );
+}
+
+Map<String, dynamic> _$NutrientsModelToJson(NutrientsModel instance) =>
+    <String, dynamic>{
+      'energy': instance.energy,
+      'protein': instance.protein,
+      'lipid': instance.lipid,
+      'carbohydrate': instance.carbohydrate,
+      'sodium': instance.sodium,
+      'calcium': instance.calcium,
+      'magnesium': instance.magnesium,
+      'iron': instance.iron,
+      'zinc': instance.zinc,
+      'retinol': instance.retinol,
+      'vitaminB1': instance.vitaminB1,
+      'vitaminB2': instance.vitaminB2,
+      'vitaminC': instance.vitaminC,
+      'dietaryFiber': instance.dietaryFiber,
+      'salt': instance.salt,
+    };

--- a/lib/model/quantity/quantity_model.dart
+++ b/lib/model/quantity/quantity_model.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'quantity_model.g.dart';
+
+@JsonSerializable()
+class QuantityModel {
+  QuantityModel({
+    this.piece,
+    this.gram = 0.0
+  });
+
+  factory QuantityModel.fromJson(Map<String, dynamic> json) =>
+      _$QuantityModelFromJson(json);
+  Map<String, dynamic> toJson() => _$QuantityModelToJson(this);
+
+  final int? piece;   // 個数
+  final double gram;  // 量(g)
+}

--- a/lib/model/quantity/quantity_model.g.dart
+++ b/lib/model/quantity/quantity_model.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'quantity_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+QuantityModel _$QuantityModelFromJson(Map<String, dynamic> json) {
+  return QuantityModel(
+    piece: json['piece'] as int?,
+    gram: (json['gram'] as num).toDouble(),
+  );
+}
+
+Map<String, dynamic> _$QuantityModelToJson(QuantityModel instance) =>
+    <String, dynamic>{
+      'piece': instance.piece,
+      'gram': instance.gram,
+    };

--- a/lib/model/school/school_model.dart
+++ b/lib/model/school/school_model.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'school_model.g.dart';
+
+@JsonSerializable()
+class SchoolModel {
+  SchoolModel({
+    required this.name,
+    required this.lunchBlock,
+    this.classification
+  });
+
+  factory SchoolModel.fromJson(Map<String, dynamic> json) =>
+      _$SchoolModelFromJson(json);
+  Map<String, dynamic> toJson() => _$SchoolModelToJson(this);
+
+  final String name;          // 学校名
+  final int lunchBlock;       // 給食区分: 1 ~ 6
+  final int? classification;  // 学校区分: {0: 小学校, 1: 中学校}
+}

--- a/lib/model/school/school_model.g.dart
+++ b/lib/model/school/school_model.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'school_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SchoolModel _$SchoolModelFromJson(Map<String, dynamic> json) {
+  return SchoolModel(
+    name: json['name'] as String,
+    lunchBlock: json['lunchBlock'] as int,
+    classification: json['classification'] as int?,
+  );
+}
+
+Map<String, dynamic> _$SchoolModelToJson(SchoolModel instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'lunchBlock': instance.lunchBlock,
+      'classification': instance.classification,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -271,12 +271,19 @@ packages:
     source: hosted
     version: "0.6.3"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.4"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,9 @@ dependencies:
   flutter_riverpod: ^1.0.0-dev.5
   freezed_annotation: ^0.14.2
 
+  # Json変換用
+  json_annotation: ^4.0.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -39,6 +42,7 @@ dev_dependencies:
   build_runner: ^2.0.6
   freezed: ^0.14.2
 
+  json_serializable: ^4.1.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## 概要
1日の献立を表現するためのモデルの構築を行なった．最終的なものは以下．

**構成**
- MenuModel menu : 1日の献立クラス
    - DateTime day : 日付
    - SchoolModel school : 学校
        - String name : 学校名
        - int lunch_block : 給食区分
        - int? classification : 学校区分
    - List\<DishModel> dishes : 料理リスト
        - String name : 料理名
        - String? category : 分類(主菜・副菜など)
        - List\<FoodstuffModel> foodstuffs : 食材リスト
            - String name : 食材名
            - bool isAllergy : true - アレルギー食材
            - QuantityModel quantity : 分量
                - double? piece : 個数
                - double gram : 量(g)
            - bool isHeat : true - 熱加工食材
            - NutrientsModel nutrients : 栄養価
                - double energy : エネルギー
                - double  protein : タンパク質
                - double  lipid : 脂質
                - double carbohydrate : 炭水化物
                - double sodium : ナトリウム
                - double calcium : カルシウム
                - double magnesium : マグネシウム
                - double iron : 鉄分
                - double zinc : 亜鉛
                - double retinol : レチノール活性当量(≒ビタミンA)
                - double vitamin_b1 : ビタミンB1
                - double vitamin_b2 : ビタミンB2
                - double vitamin_c : ビタミンC
                - double dietary_fiber : 食物繊維
                - double salt : 塩分相当量

各モデルにそれぞれJsonとの変換関数の実装(v1では読み込みのみを利用しているが，今度書き出しの機会もあり得るのでToJson()も実装)

## 関連Issue
Close #1 