### PR TITLE
SQLiteの操作における競合処理の追加

### DIFF
--- a/android/app/src/main/kotlin/jp/ac/fun/hakondate_v2/MainActivity.kt
+++ b/android/app/src/main/kotlin/jp/ac/fun/hakondate_v2/MainActivity.kt
@@ -1,4 +1,4 @@
-package jp.ac.fun.hakondate_v2
+package jp.ac.`fun`.hakondate_v2
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/assets/debug/demo_menus.json
+++ b/assets/debug/demo_menus.json
@@ -308,11 +308,11 @@
         "event": null,
         "dishes": [
             {
-                "name": "ごはん",
+                "name": "ごはんちゃん",
                 "category": "主食",
                 "foodstuffs": [
                     {
-                        "name": "精白米",
+                        "name": "精白米ちゃん",
                         "piece": null,
                         "gram": 100.0,
                         "energy": 358,
@@ -337,11 +337,11 @@
                 ]
             },
             {
-                "name": "牛乳",
+                "name": "牛乳ちゃん",
                 "category": "飲み物",
                 "foodstuffs": [
                     {
-                        "name": "牛乳",
+                        "name": "牛乳ちゃん",
                         "piece": null,
                         "gram": 206.0,
                         "energy": 138,
@@ -366,11 +366,11 @@
                 ]
             },
             {
-                "name": "五目あんかけ豆腐",
+                "name": "五目あんかけ豆腐ちゃん",
                 "category": "主菜",
                 "foodstuffs": [
                     {
-                        "name": "豆腐",
+                        "name": "豆腐ちゃん",
                         "piece": null,
                         "gram": 150.0,
                         "energy": 89,
@@ -393,7 +393,7 @@
                         "origin": null
                     },
                     {
-                        "name": "豚ももスライス",
+                        "name": "豚ももスライスちゃん",
                         "piece": null,
                         "gram": 15.0,
                         "energy": 27,
@@ -416,7 +416,7 @@
                         "origin": null
                     },
                     {
-                        "name": "玉ねぎ",
+                        "name": "玉ねぎちゃん",
                         "piece": null,
                         "gram": 35.0,
                         "energy": 13,
@@ -439,7 +439,7 @@
                         "origin": null
                     },
                     {
-                        "name": "たけのこ",
+                        "name": "たけのこちゃん",
                         "piece": null,
                         "gram": 10.0,
                         "energy": 2,
@@ -462,7 +462,7 @@
                         "origin": null
                     },
                     {
-                        "name": "人参",
+                        "name": "人参ちゃん",
                         "piece": null,
                         "gram": 15.0,
                         "energy": 5,
@@ -485,7 +485,7 @@
                         "origin": "函館市"
                     },
                     {
-                        "name": "長ねぎ",
+                        "name": "長ねぎちゃん",
                         "piece": null,
                         "gram": 15.0,
                         "energy": 5,
@@ -508,7 +508,7 @@
                         "origin": null
                     },
                     {
-                        "name": "さやいんげん",
+                        "name": "さやいんげんちゃん",
                         "piece": null,
                         "gram": 6.0,
                         "energy": 2,
@@ -531,7 +531,7 @@
                         "origin": null
                     },
                     {
-                        "name": "サラダ油",
+                        "name": "サラダ油ちゃん",
                         "piece": null,
                         "gram": 2.0,
                         "energy": 18,
@@ -554,7 +554,7 @@
                         "origin": null
                     },
                     {
-                        "name": "上白糖",
+                        "name": "上白糖ちゃん",
                         "piece": null,
                         "gram": 1.8,
                         "energy": 7,
@@ -577,7 +577,7 @@
                         "origin": null
                     },
                     {
-                        "name": "水",
+                        "name": "水ちゃん",
                         "piece": null,
                         "gram": 45.0,
                         "energy": 0,

--- a/lib/provider/user/user_state.dart
+++ b/lib/provider/user/user_state.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:hakondate_v2/model/user/user_model.dart';

--- a/lib/repository/local/database_manager.dart
+++ b/lib/repository/local/database_manager.dart
@@ -43,8 +43,13 @@ class DatabaseManager extends _$DatabaseManager {
   Future<List<MenusSchema>> get allMenusSchemas => select(menusTable).get();
 
   // 範囲指定でのデータ取得
-  Future<List<MenusSchema>> getSelectionPeriodMenusSchemas(DateTime startDay, DateTime endDay, int schoolId) =>
-      (select(menusTable)..where((t) => t.day.isBetweenValues(startDay, endDay) & t.schoolId.equals(schoolId))).get();
+  Future<List<MenusSchema>> getSelectionPeriodMenusSchemas(
+          DateTime startDay, DateTime endDay, int schoolId) =>
+      (select(menusTable)
+            ..where((t) =>
+                t.day.isBetweenValues(startDay, endDay) &
+                t.schoolId.equals(schoolId)))
+          .get();
 
   // IDからMenusSchemaを取得
   Future<MenusSchema> getMenusSchemaById(int id) =>
@@ -73,25 +78,40 @@ class DatabaseManager extends _$DatabaseManager {
   /* INSERT */
   // MenusSchemaを追加
   Future<int> addMenusSchema(MenusTableCompanion entry) =>
-      into(menusTable).insert(entry);
+      into(menusTable).insert(
+          entry,
+          onConflict: DoUpdate((old) => MenusTableCompanion.custom(
+              event: Constant(entry.event.value)
+          ))
+      );
 
   // SchoolsSchemaを追加
   Future<int> addSchoolsSchema(SchoolsTableCompanion entry) =>
-      into(schoolsTable).insert(entry);
+      into(schoolsTable).insertOnConflictUpdate(entry);
 
   // MenuDishesSchemaを追加
   Future<int> addMenuDishesSchema(MenuDishesTableCompanion entry) =>
-      into(menuDishesTable).insert(entry);
+      into(menuDishesTable).insertOnConflictUpdate(entry);
 
   // DishesSchemaを追加
   Future<int> addDishesSchema(DishesTableCompanion entry) =>
-      into(dishesTable).insert(entry);
+      into(dishesTable).insert(
+          entry,
+          onConflict: DoUpdate((old) => DishesTableCompanion.custom(
+              category: Constant(entry.category.value)
+          ))
+      );
 
   // DishFoodstuffsSchemaを追加
   Future<int> addDishFoodstuffsSchema(DishFoodstuffsTableCompanion entry) =>
-      into(dishFoodstuffsTable).insert(entry);
+      into(dishFoodstuffsTable).insertOnConflictUpdate(entry);
 
   // FoodstuffsSchemaを追加
   Future<int> addFoodstuffsSchema(FoodstuffsTableCompanion entry) =>
-      into(foodstuffsTable).insert(entry);
+      into(foodstuffsTable).insert(
+          entry,
+          onConflict: DoUpdate((old) => FoodstuffsTableCompanion.custom(
+            origin: Constant(entry.origin.value)
+          ))
+      );
 }

--- a/lib/repository/local/database_manager.dart
+++ b/lib/repository/local/database_manager.dart
@@ -43,13 +43,8 @@ class DatabaseManager extends _$DatabaseManager {
   Future<List<MenusSchema>> get allMenusSchemas => select(menusTable).get();
 
   // 範囲指定でのデータ取得
-  Future<List<MenusSchema>> getSelectionPeriodMenusSchemas(
-          DateTime startDay, DateTime endDay, int schoolId) =>
-      (select(menusTable)
-            ..where((t) =>
-                t.day.isBetweenValues(startDay, endDay) &
-                t.schoolId.equals(schoolId)))
-          .get();
+  Future<List<MenusSchema>> getSelectionPeriodMenusSchemas(DateTime startDay, DateTime endDay, int schoolId) =>
+      (select(menusTable)..where((t) => t.day.isBetweenValues(startDay, endDay) & t.schoolId.equals(schoolId))).get();
 
   // IDからMenusSchemaを取得
   Future<MenusSchema> getMenusSchemaById(int id) =>

--- a/lib/repository/local/database_manager.g.dart
+++ b/lib/repository/local/database_manager.g.dart
@@ -704,7 +704,7 @@ class $MenuDishesTableTable extends MenuDishesTable
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => <GeneratedColumn>{};
+  Set<GeneratedColumn> get $primaryKey => {menuId, dishId};
   @override
   MenuDishesSchema map(Map<String, dynamic> data, {String? tablePrefix}) {
     return MenuDishesSchema.fromData(data, _db,
@@ -1094,7 +1094,7 @@ class $DishFoodstuffsTableTable extends DishFoodstuffsTable
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => <GeneratedColumn>{};
+  Set<GeneratedColumn> get $primaryKey => {dishId, foodstuffId};
   @override
   DishFoodstuffsSchema map(Map<String, dynamic> data, {String? tablePrefix}) {
     return DishFoodstuffsSchema.fromData(data, _db,

--- a/lib/repository/local/database_manager.g.dart
+++ b/lib/repository/local/database_manager.g.dart
@@ -877,7 +877,9 @@ class $DishesTableTable extends DishesTable
   final VerificationMeta _nameMeta = const VerificationMeta('name');
   late final GeneratedColumn<String?> name = GeneratedColumn<String?>(
       'name', aliasedName, false,
-      typeName: 'TEXT', requiredDuringInsert: true);
+      typeName: 'TEXT',
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL UNIQUE');
   final VerificationMeta _categoryMeta = const VerificationMeta('category');
   late final GeneratedColumn<String?> category = GeneratedColumn<String?>(
       'category', aliasedName, true,

--- a/lib/repository/local/menus_local_repository.dart
+++ b/lib/repository/local/menus_local_repository.dart
@@ -14,8 +14,6 @@ class MenusLocalRepository {
   late final DatabaseManager _databaseManager;
 
   Future<int> addMenu(Map<String, dynamic> menu) async {
-    // TODO: 各スキーマの競合の解決処理を書く(仕様がよくわからん)
-    // KEYWORDS: UNIQUE制約 UPSERT
     final MenusTableCompanion _menusSchema = MenusTableCompanion(
       id: Value(menu['id']),
       day: Value(DateTime.fromMillisecondsSinceEpoch(menu['day'])),

--- a/lib/repository/local/table/dish_foodstuffs_table.dart
+++ b/lib/repository/local/table/dish_foodstuffs_table.dart
@@ -8,6 +8,7 @@ class DishFoodstuffsTable extends Table {
   @override
   List<String> get customConstraints => [
     'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)',
-    'FOREIGN KEY(foodstuff_id) REFERENCES foodstuffs_table(id)'
+    'FOREIGN KEY(foodstuff_id) REFERENCES foodstuffs_table(id)',
+    'UNIQUE (dishId, foodstuffId)'
   ];
 }

--- a/lib/repository/local/table/dish_foodstuffs_table.dart
+++ b/lib/repository/local/table/dish_foodstuffs_table.dart
@@ -6,9 +6,11 @@ class DishFoodstuffsTable extends Table {
   IntColumn get foodstuffId => integer()();
 
   @override
+  Set<Column> get primaryKey => {dishId, foodstuffId};
+
+  @override
   List<String> get customConstraints => [
     'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)',
-    'FOREIGN KEY(foodstuff_id) REFERENCES foodstuffs_table(id)',
-    'UNIQUE (dishId, foodstuffId)'
+    'FOREIGN KEY(foodstuff_id) REFERENCES foodstuffs_table(id)'
   ];
 }

--- a/lib/repository/local/table/dishes_table.dart
+++ b/lib/repository/local/table/dishes_table.dart
@@ -3,6 +3,6 @@ import 'package:moor/moor.dart';
 @DataClassName('DishesSchema')
 class DishesTable extends Table {
   IntColumn get id => integer().autoIncrement()();
-  TextColumn get name => text()();
+  TextColumn get name => text().customConstraint('NOT NULL UNIQUE')();
   TextColumn get category => text().nullable()();
 }

--- a/lib/repository/local/table/foodstuffs_table.dart
+++ b/lib/repository/local/table/foodstuffs_table.dart
@@ -28,6 +28,6 @@ class FoodstuffsTable extends Table {
   // 記述と処理省略のためにエネルギー量のみを参照している
   @override
   List<String> get customConstraints => [
-    'UNIQUE (name, gram, energy, isHeat, isAllergy)'
+    'UNIQUE (name, gram, energy, is_heat, is_allergy)'
   ];
 }

--- a/lib/repository/local/table/foodstuffs_table.dart
+++ b/lib/repository/local/table/foodstuffs_table.dart
@@ -25,9 +25,8 @@ class FoodstuffsTable extends Table {
   BoolColumn get isAllergy => boolean()();
   TextColumn get origin => text().nullable()();
 
-  // 記述と処理省略のためにエネルギー量のみを参照している
   @override
   List<String> get customConstraints => [
-    'UNIQUE (name, gram, energy, is_heat, is_allergy)'
+    'UNIQUE (name, gram, is_heat, is_allergy)'
   ];
 }

--- a/lib/repository/local/table/foodstuffs_table.dart
+++ b/lib/repository/local/table/foodstuffs_table.dart
@@ -28,6 +28,6 @@ class FoodstuffsTable extends Table {
   // 記述と処理省略のためにエネルギー量のみを参照している
   @override
   List<String> get customConstraints => [
-    'UNIQUE (name, gram, energy, isHeat, isAllergy, origin)'
+    'UNIQUE (name, gram, energy, isHeat, isAllergy)'
   ];
 }

--- a/lib/repository/local/table/foodstuffs_table.dart
+++ b/lib/repository/local/table/foodstuffs_table.dart
@@ -24,4 +24,10 @@ class FoodstuffsTable extends Table {
   BoolColumn get isHeat => boolean()();
   BoolColumn get isAllergy => boolean()();
   TextColumn get origin => text().nullable()();
+
+  // 記述と処理省略のためにエネルギー量のみを参照している
+  @override
+  List<String> get customConstraints => [
+    'UNIQUE (name, gram, energy, isHeat, isAllergy, origin)'
+  ];
 }

--- a/lib/repository/local/table/menu_dishes_table.dart
+++ b/lib/repository/local/table/menu_dishes_table.dart
@@ -8,6 +8,7 @@ class MenuDishesTable extends Table {
   @override
   List<String> get customConstraints => [
     'FOREIGN KEY(menu_id) REFERENCES menus_table(id)',
-    'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)'
+    'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)',
+    'UNIQUE (menuId, dishId)'
   ];
 }

--- a/lib/repository/local/table/menu_dishes_table.dart
+++ b/lib/repository/local/table/menu_dishes_table.dart
@@ -6,9 +6,11 @@ class MenuDishesTable extends Table {
   IntColumn get dishId => integer()();
 
   @override
+  Set<Column> get primaryKey => {menuId, dishId};
+
+  @override
   List<String> get customConstraints => [
     'FOREIGN KEY(menu_id) REFERENCES menus_table(id)',
-    'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)',
-    'UNIQUE (menuId, dishId)'
+    'FOREIGN KEY(dish_id) REFERENCES dishes_table(id)'
   ];
 }


### PR DESCRIPTION
- 各テーブルについて主キーの見直しやUNIQUE制約の追加
- データのINSERT時に競合の検索や，競合が発生した場合の処理を追加

残っている問題としては，動作の重さが結構あるように感じるので軽くできたらベスト