### PR TITLE
Navigator2.0の実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,24 +33,5 @@ class Hakondate extends StatelessWidget {
         debugShowCheckedModeBanner: false,
       ),
     );
-
-    //MaterialApp(
-    //         title: 'はこんだて',
-    //         theme: ThemeData(
-    //           fontFamily: 'MPLUSRounded1c',
-    //           primaryColor: Colors.white,
-    //           accentColor: Colors.orangeAccent,
-    //           primaryTextTheme:
-    //               TextTheme(headline6: TextStyle(color: Color(0xFF373737))),
-    //           accentTextTheme:
-    //               TextTheme(bodyText2: TextStyle(color: Colors.blueAccent)),
-    //           primaryIconTheme: IconThemeData(color: Colors.orangeAccent),
-    //           textSelectionTheme: TextSelectionThemeData(
-    //             selectionColor: Colors.blueAccent,
-    //           ),
-    //         ),
-    //         home: Splash(),
-    //         debugShowCheckedModeBanner: false,
-    //       )
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ void main() {
 }
 
 class Hakondate extends StatelessWidget {
-  final _routeInformationParser = VoidRouteInformationParser();
+  final _routeInformationParser = ListRouteInformationParser();
   final _appRouterDelegate = AppRouterDelegate();
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hakondate_v2/view/splash.dart';
-import 'package:hakondate_v2/view/terms.dart';
+import 'package:hakondate_v2/router/app_router_delegate.dart';
 
 void main() {
   runApp(Hakondate());
 }
 
 class Hakondate extends StatelessWidget {
+  final _routeInformationParser = VoidRouteInformationParser();
+  final _appRouterDelegate = AppRouterDelegate();
+
   @override
   Widget build(BuildContext context) {
     return ProviderScope(
-      child: MaterialApp(
+      child: MaterialApp.router(
         title: 'はこんだて',
         theme: ThemeData(
           fontFamily: 'MPLUSRounded1c',
@@ -26,9 +28,29 @@ class Hakondate extends StatelessWidget {
             selectionColor: Colors.blueAccent,
           ),
         ),
-        home: Splash(),
+        routeInformationParser: _routeInformationParser,
+        routerDelegate: _appRouterDelegate,
         debugShowCheckedModeBanner: false,
       ),
     );
+
+    //MaterialApp(
+    //         title: 'はこんだて',
+    //         theme: ThemeData(
+    //           fontFamily: 'MPLUSRounded1c',
+    //           primaryColor: Colors.white,
+    //           accentColor: Colors.orangeAccent,
+    //           primaryTextTheme:
+    //               TextTheme(headline6: TextStyle(color: Color(0xFF373737))),
+    //           accentTextTheme:
+    //               TextTheme(bodyText2: TextStyle(color: Colors.blueAccent)),
+    //           primaryIconTheme: IconThemeData(color: Colors.orangeAccent),
+    //           textSelectionTheme: TextSelectionThemeData(
+    //             selectionColor: Colors.blueAccent,
+    //           ),
+    //         ),
+    //         home: Splash(),
+    //         debugShowCheckedModeBanner: false,
+    //       )
   }
 }

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hakondate_v2/state/navigator/app_navigator_state.dart';
+
+final routerProvider = StateNotifierProvider<AppNavigatorStateNotifier, AppNavigatorState>(
+        (ref) => AppNavigatorStateNotifier());
+
+class AppNavigatorStateNotifier extends StateNotifier<AppNavigatorState> {
+  AppNavigatorStateNotifier() : super(AppNavigatorState());
+}

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -6,4 +6,7 @@ final routerProvider = StateNotifierProvider<AppNavigatorStateNotifier, AppNavig
 
 class AppNavigatorStateNotifier extends StateNotifier<AppNavigatorState> {
   AppNavigatorStateNotifier() : super(AppNavigatorState());
+
+  void handleFromSplash({bool isExistUser = true}) =>
+      state = state.copyWith(isInitialLoading: false, isShowTerms: !isExistUser);
 }

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -1,14 +1,25 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hakondate_v2/state/navigator/app_navigator_state.dart';
 
-final routerProvider = StateNotifierProvider<AppNavigatorStateNotifier, AppNavigatorState>(
+final routerProvider =
+    StateNotifierProvider<AppNavigatorStateNotifier, AppNavigatorState>(
         (ref) => AppNavigatorStateNotifier());
 
 class AppNavigatorStateNotifier extends StateNotifier<AppNavigatorState> {
   AppNavigatorStateNotifier() : super(AppNavigatorState());
 
-  void handleFromSplash({bool isExistUser = true}) =>
-      state = state.copyWith(isInitialLoading: false, isShowTerms: !isExistUser);
+  void handleFromSplash({bool toTerms = false}) =>
+      state = state.copyWith(isInitialLoading: false, isShowTerms: toTerms);
 
-  void handleFromTerms() => state = state.copyWith(isShowTerms: false, isShowSignup: true);
+  void handleFromTerms() =>
+      state = state.copyWith(isShowTerms: false, isShowSignup: true);
+
+  void handleFromSignup() =>
+      state = state.copyWith(isShowSignup: false, isShowConfirmation: true);
+
+  void handleFromConfirmation({bool toSignup = false}) =>
+      state = state.copyWith(isShowSignup: toSignup, isShowConfirmation: false);
+
+  void handleFromHome({bool toSetting = false, bool toAboutUs = false, bool toHelp = false}) =>
+      state = state.copyWith(isShowSetting: toSetting, isShowAboutUs: toAboutUs, isShowHelp: toHelp);
 }

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -9,4 +9,6 @@ class AppNavigatorStateNotifier extends StateNotifier<AppNavigatorState> {
 
   void handleFromSplash({bool isExistUser = true}) =>
       state = state.copyWith(isInitialLoading: false, isShowTerms: !isExistUser);
+
+  void handleFromTerms() => state = state.copyWith(isShowTerms: false, isShowSignup: true);
 }

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -22,4 +22,6 @@ class AppNavigatorStateNotifier extends StateNotifier<AppNavigatorState> {
 
   void handleFromHome({bool toSetting = false, bool toAboutUs = false, bool toHelp = false}) =>
       state = state.copyWith(isShowSetting: toSetting, isShowAboutUs: toAboutUs, isShowHelp: toHelp);
+
+  void handleToHome() => state = state.copyWith(isShowSetting: false, isShowAboutUs: false, isShowHelp: false);
 }

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -41,11 +41,11 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
                 key: ValueKey('signup'),
                 child: Scaffold(),
               ),
-              if (_router.isShowConfirmation)
-                MaterialPage(
-                  key: ValueKey('confirmation'),
-                  child: Scaffold(),
-                )
+            ] else if (_router.isShowConfirmation) ...[
+              MaterialPage(
+                key: ValueKey('confirmation'),
+                child: Scaffold(),
+              ),
             ] else ...[
               MaterialPage(
                 key: ValueKey('home'),

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -12,8 +12,13 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
   @override
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-  bool _handlePopPage(Route<dynamic> route, dynamic result) {
+  bool _handlePopPage(Route<dynamic> route, dynamic result, WidgetRef ref) {
     if (!route.didPop(result)) return false;
+
+    final _router = ref.watch(routerProvider);
+    if (_router.isShowSetting || _router.isShowAboutUs || _router.isShowHelp)
+      ref.read(routerProvider.notifier).handleToHome();
+
     return true;
   }
 
@@ -24,7 +29,8 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
         final _router = ref.watch(routerProvider);
         return Navigator(
           key: navigatorKey,
-          onPopPage: _handlePopPage,
+          onPopPage: (Route<dynamic> route, dynamic result) =>
+              _handlePopPage(route, result, ref),
           pages: [
             if (_router.isInitialLoading) ...[
               MaterialPage(

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hakondate_v2/router/app_navigator_state_notifier.dart';
+import 'package:hakondate_v2/view/splash.dart';
+import 'package:hakondate_v2/view/terms.dart';
+
+class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavigatorRouterDelegateMixin {
+  AppRouterDelegate();
+
+  @override
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+  bool _handlePopPage(Route<dynamic> route, dynamic result) {
+    if (!route.didPop(result)) return false;
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer(
+      builder: (BuildContext context, WidgetRef ref, _) {
+        final _router = ref.watch(routerProvider);
+        return Navigator(
+          key: navigatorKey,
+          onPopPage: _handlePopPage,
+          pages: [
+            if (_router.isInitialLoading) ...[
+              MaterialPage(
+                key: ValueKey('splash'),
+                child: Splash(),
+              ),
+            ] else if (_router.isShowTerms) ...[
+              MaterialPage(
+                key: ValueKey('terms'),
+                child: Terms(),
+              ),
+            ] else if (_router.isShowSignup) ...[
+              MaterialPage(
+                key: ValueKey('signup'),
+                child: Scaffold(),
+              ),
+              if (_router.isShowConfirmation)
+                MaterialPage(
+                  key: ValueKey('confirmation'),
+                  child: Scaffold(),
+                )
+            ] else ...[
+              MaterialPage(
+                key: ValueKey('home'),
+                child: Scaffold(),
+              ),
+              if (_router.isShowSetting)
+                MaterialPage(
+                  key: ValueKey('setting'),
+                  child: Scaffold(),
+                ),
+              if (_router.isShowAboutUs)
+                MaterialPage(
+                  key: ValueKey('aboutUs'),
+                  child: Scaffold(),
+                ),
+              if (_router.isShowHelp)
+                MaterialPage(
+                  key: ValueKey('help'),
+                  child: Scaffold(),
+                ),
+            ],
+          ],
+        );
+      }
+    );
+  }
+
+  /*
+  * 主にWebやディープリンク(OSからの通知で起動など)用
+  * 使わなくても宣言しなくてはいけないので記述
+  */
+  @override
+  void addListener(VoidCallback listener) {}
+  @override
+  void removeListener(VoidCallback listener) {}
+  @override
+  Future<void> setNewRoutePath(List<RouteSettings> configuration) async {}
+}
+
+/*
+* WebのURL制御などに使う
+* はこんだてはモバイル限定なので空のものを宣言
+*/
+class VoidRouteInformationParser extends RouteInformationParser<List<RouteSettings>> {
+  @override
+  Future<List<RouteSettings>> parseRouteInformation(RouteInformation routeInformation) async => [];
+}

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -96,7 +96,7 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
 * WebのURL制御などに使う
 * はこんだてはモバイル限定なので空のものを宣言
 */
-class VoidRouteInformationParser extends RouteInformationParser<List<RouteSettings>> {
+class ListRouteInformationParser extends RouteInformationParser<List<RouteSettings>> {
   @override
   Future<List<RouteSettings>> parseRouteInformation(RouteInformation routeInformation) async => [];
 }

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -53,6 +53,7 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
                 child: Scaffold(),
               ),
             ] else ...[
+              // TODO: HOME内のNavigatorの実装
               MaterialPage(
                 key: ValueKey('home'),
                 child: Scaffold(),

--- a/lib/state/navigator/app_navigator_state.dart
+++ b/lib/state/navigator/app_navigator_state.dart
@@ -10,13 +10,15 @@ class AppNavigatorState with _$AppNavigatorState {
     @Default(false) bool isShowTerms,
     @Default(false) bool isShowSignup,
     @Default(false) bool isShowConfirmation,
-    // @Default(false) bool isShowMenuList,
-    // int? selectedMenuId,
-    // int? selectedDishId,
-    // int? selectedPopularRecipeId,
-    // int? selectedMonthlyOriginId,
     @Default(false) bool isShowSetting,
     @Default(false) bool isShowHelp,
     @Default(false) bool isShowAboutUs,
   }) = _AppNavigatorState;
 }
+
+// Home内の遷移で少なくても必要になるやつら
+// @Default(false) bool isShowMenuList,
+// int? selectedMenuId,
+// int? selectedDishId,
+// int? selectedPopularRecipeId,
+// int? selectedMonthlyOriginId,

--- a/lib/state/navigator/app_navigator_state.dart
+++ b/lib/state/navigator/app_navigator_state.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_navigator_state.freezed.dart';
+
+@freezed
+class AppNavigatorState with _$AppNavigatorState {
+  const factory AppNavigatorState({
+    @Default(true) bool isInitialLoading,
+    @Default(false) bool isShowTerms,
+    @Default(false) bool isShowSignup,
+    @Default(false) bool isShowConfirmation,
+    // @Default(false) bool isShowMenuList,
+    // int? selectedMenuId,
+    // int? selectedDishId,
+    // int? selectedPopularRecipeId,
+    // int? selectedMonthlyOriginId,
+    @Default(false) bool isShowSetting,
+    @Default(false) bool isShowHelp,
+    @Default(false) bool isShowAboutUs,
+  }) = _AppNavigatorState;
+}

--- a/lib/state/navigator/app_navigator_state.freezed.dart
+++ b/lib/state/navigator/app_navigator_state.freezed.dart
@@ -1,0 +1,335 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
+
+part of 'app_navigator_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$AppNavigatorStateTearOff {
+  const _$AppNavigatorStateTearOff();
+
+  _AppNavigatorState call(
+      {bool isInitialLoading = true,
+      bool isShowTerms = false,
+      bool isShowSignup = false,
+      bool isShowConfirmation = false,
+      bool isShowSetting = false,
+      bool isShowHelp = false,
+      bool isShowAboutUs = false}) {
+    return _AppNavigatorState(
+      isInitialLoading: isInitialLoading,
+      isShowTerms: isShowTerms,
+      isShowSignup: isShowSignup,
+      isShowConfirmation: isShowConfirmation,
+      isShowSetting: isShowSetting,
+      isShowHelp: isShowHelp,
+      isShowAboutUs: isShowAboutUs,
+    );
+  }
+}
+
+/// @nodoc
+const $AppNavigatorState = _$AppNavigatorStateTearOff();
+
+/// @nodoc
+mixin _$AppNavigatorState {
+  bool get isInitialLoading => throw _privateConstructorUsedError;
+  bool get isShowTerms => throw _privateConstructorUsedError;
+  bool get isShowSignup => throw _privateConstructorUsedError;
+  bool get isShowConfirmation =>
+      throw _privateConstructorUsedError; // @Default(false) bool isShowMenuList,
+// int? selectedMenuId,
+// int? selectedDishId,
+// int? selectedPopularRecipeId,
+// int? selectedMonthlyOriginId,
+  bool get isShowSetting => throw _privateConstructorUsedError;
+  bool get isShowHelp => throw _privateConstructorUsedError;
+  bool get isShowAboutUs => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $AppNavigatorStateCopyWith<AppNavigatorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppNavigatorStateCopyWith<$Res> {
+  factory $AppNavigatorStateCopyWith(
+          AppNavigatorState value, $Res Function(AppNavigatorState) then) =
+      _$AppNavigatorStateCopyWithImpl<$Res>;
+  $Res call(
+      {bool isInitialLoading,
+      bool isShowTerms,
+      bool isShowSignup,
+      bool isShowConfirmation,
+      bool isShowSetting,
+      bool isShowHelp,
+      bool isShowAboutUs});
+}
+
+/// @nodoc
+class _$AppNavigatorStateCopyWithImpl<$Res>
+    implements $AppNavigatorStateCopyWith<$Res> {
+  _$AppNavigatorStateCopyWithImpl(this._value, this._then);
+
+  final AppNavigatorState _value;
+  // ignore: unused_field
+  final $Res Function(AppNavigatorState) _then;
+
+  @override
+  $Res call({
+    Object? isInitialLoading = freezed,
+    Object? isShowTerms = freezed,
+    Object? isShowSignup = freezed,
+    Object? isShowConfirmation = freezed,
+    Object? isShowSetting = freezed,
+    Object? isShowHelp = freezed,
+    Object? isShowAboutUs = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isInitialLoading: isInitialLoading == freezed
+          ? _value.isInitialLoading
+          : isInitialLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowTerms: isShowTerms == freezed
+          ? _value.isShowTerms
+          : isShowTerms // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowSignup: isShowSignup == freezed
+          ? _value.isShowSignup
+          : isShowSignup // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowConfirmation: isShowConfirmation == freezed
+          ? _value.isShowConfirmation
+          : isShowConfirmation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowSetting: isShowSetting == freezed
+          ? _value.isShowSetting
+          : isShowSetting // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowHelp: isShowHelp == freezed
+          ? _value.isShowHelp
+          : isShowHelp // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowAboutUs: isShowAboutUs == freezed
+          ? _value.isShowAboutUs
+          : isShowAboutUs // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$AppNavigatorStateCopyWith<$Res>
+    implements $AppNavigatorStateCopyWith<$Res> {
+  factory _$AppNavigatorStateCopyWith(
+          _AppNavigatorState value, $Res Function(_AppNavigatorState) then) =
+      __$AppNavigatorStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {bool isInitialLoading,
+      bool isShowTerms,
+      bool isShowSignup,
+      bool isShowConfirmation,
+      bool isShowSetting,
+      bool isShowHelp,
+      bool isShowAboutUs});
+}
+
+/// @nodoc
+class __$AppNavigatorStateCopyWithImpl<$Res>
+    extends _$AppNavigatorStateCopyWithImpl<$Res>
+    implements _$AppNavigatorStateCopyWith<$Res> {
+  __$AppNavigatorStateCopyWithImpl(
+      _AppNavigatorState _value, $Res Function(_AppNavigatorState) _then)
+      : super(_value, (v) => _then(v as _AppNavigatorState));
+
+  @override
+  _AppNavigatorState get _value => super._value as _AppNavigatorState;
+
+  @override
+  $Res call({
+    Object? isInitialLoading = freezed,
+    Object? isShowTerms = freezed,
+    Object? isShowSignup = freezed,
+    Object? isShowConfirmation = freezed,
+    Object? isShowSetting = freezed,
+    Object? isShowHelp = freezed,
+    Object? isShowAboutUs = freezed,
+  }) {
+    return _then(_AppNavigatorState(
+      isInitialLoading: isInitialLoading == freezed
+          ? _value.isInitialLoading
+          : isInitialLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowTerms: isShowTerms == freezed
+          ? _value.isShowTerms
+          : isShowTerms // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowSignup: isShowSignup == freezed
+          ? _value.isShowSignup
+          : isShowSignup // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowConfirmation: isShowConfirmation == freezed
+          ? _value.isShowConfirmation
+          : isShowConfirmation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowSetting: isShowSetting == freezed
+          ? _value.isShowSetting
+          : isShowSetting // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowHelp: isShowHelp == freezed
+          ? _value.isShowHelp
+          : isShowHelp // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShowAboutUs: isShowAboutUs == freezed
+          ? _value.isShowAboutUs
+          : isShowAboutUs // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_AppNavigatorState
+    with DiagnosticableTreeMixin
+    implements _AppNavigatorState {
+  const _$_AppNavigatorState(
+      {this.isInitialLoading = true,
+      this.isShowTerms = false,
+      this.isShowSignup = false,
+      this.isShowConfirmation = false,
+      this.isShowSetting = false,
+      this.isShowHelp = false,
+      this.isShowAboutUs = false});
+
+  @JsonKey(defaultValue: true)
+  @override
+  final bool isInitialLoading;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isShowTerms;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isShowSignup;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isShowConfirmation;
+  @JsonKey(defaultValue: false)
+  @override // @Default(false) bool isShowMenuList,
+// int? selectedMenuId,
+// int? selectedDishId,
+// int? selectedPopularRecipeId,
+// int? selectedMonthlyOriginId,
+  final bool isShowSetting;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isShowHelp;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool isShowAboutUs;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'AppNavigatorState(isInitialLoading: $isInitialLoading, isShowTerms: $isShowTerms, isShowSignup: $isShowSignup, isShowConfirmation: $isShowConfirmation, isShowSetting: $isShowSetting, isShowHelp: $isShowHelp, isShowAboutUs: $isShowAboutUs)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'AppNavigatorState'))
+      ..add(DiagnosticsProperty('isInitialLoading', isInitialLoading))
+      ..add(DiagnosticsProperty('isShowTerms', isShowTerms))
+      ..add(DiagnosticsProperty('isShowSignup', isShowSignup))
+      ..add(DiagnosticsProperty('isShowConfirmation', isShowConfirmation))
+      ..add(DiagnosticsProperty('isShowSetting', isShowSetting))
+      ..add(DiagnosticsProperty('isShowHelp', isShowHelp))
+      ..add(DiagnosticsProperty('isShowAboutUs', isShowAboutUs));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _AppNavigatorState &&
+            (identical(other.isInitialLoading, isInitialLoading) ||
+                const DeepCollectionEquality()
+                    .equals(other.isInitialLoading, isInitialLoading)) &&
+            (identical(other.isShowTerms, isShowTerms) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowTerms, isShowTerms)) &&
+            (identical(other.isShowSignup, isShowSignup) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowSignup, isShowSignup)) &&
+            (identical(other.isShowConfirmation, isShowConfirmation) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowConfirmation, isShowConfirmation)) &&
+            (identical(other.isShowSetting, isShowSetting) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowSetting, isShowSetting)) &&
+            (identical(other.isShowHelp, isShowHelp) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowHelp, isShowHelp)) &&
+            (identical(other.isShowAboutUs, isShowAboutUs) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowAboutUs, isShowAboutUs)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(isInitialLoading) ^
+      const DeepCollectionEquality().hash(isShowTerms) ^
+      const DeepCollectionEquality().hash(isShowSignup) ^
+      const DeepCollectionEquality().hash(isShowConfirmation) ^
+      const DeepCollectionEquality().hash(isShowSetting) ^
+      const DeepCollectionEquality().hash(isShowHelp) ^
+      const DeepCollectionEquality().hash(isShowAboutUs);
+
+  @JsonKey(ignore: true)
+  @override
+  _$AppNavigatorStateCopyWith<_AppNavigatorState> get copyWith =>
+      __$AppNavigatorStateCopyWithImpl<_AppNavigatorState>(this, _$identity);
+}
+
+abstract class _AppNavigatorState implements AppNavigatorState {
+  const factory _AppNavigatorState(
+      {bool isInitialLoading,
+      bool isShowTerms,
+      bool isShowSignup,
+      bool isShowConfirmation,
+      bool isShowSetting,
+      bool isShowHelp,
+      bool isShowAboutUs}) = _$_AppNavigatorState;
+
+  @override
+  bool get isInitialLoading => throw _privateConstructorUsedError;
+  @override
+  bool get isShowTerms => throw _privateConstructorUsedError;
+  @override
+  bool get isShowSignup => throw _privateConstructorUsedError;
+  @override
+  bool get isShowConfirmation => throw _privateConstructorUsedError;
+  @override // @Default(false) bool isShowMenuList,
+// int? selectedMenuId,
+// int? selectedDishId,
+// int? selectedPopularRecipeId,
+// int? selectedMonthlyOriginId,
+  bool get isShowSetting => throw _privateConstructorUsedError;
+  @override
+  bool get isShowHelp => throw _privateConstructorUsedError;
+  @override
+  bool get isShowAboutUs => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$AppNavigatorStateCopyWith<_AppNavigatorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/view/splash.dart
+++ b/lib/view/splash.dart
@@ -17,7 +17,7 @@ class Splash extends ConsumerWidget {
         _showErrorDialog(context);
       }
     }
-    ref.read(routerProvider.notifier).handleFromSplash(isExistUser: _isExistUser);
+    ref.read(routerProvider.notifier).handleFromSplash(toTerms: !_isExistUser);
   }
 
   void _showErrorDialog(BuildContext context) {

--- a/lib/view/splash.dart
+++ b/lib/view/splash.dart
@@ -1,38 +1,23 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hakondate_v2/model/school/users_school_model.dart';
+import 'package:hakondate_v2/router/app_navigator_state_notifier.dart';
 
 import 'package:hakondate_v2/view_model/menus_view_model.dart';
 import 'package:hakondate_v2/view_model/user_view_model.dart';
 
 class Splash extends ConsumerWidget {
   Stream<String> _initialData(BuildContext context, WidgetRef ref) async* {
-    try {
-      // デバッグ用
-      await ref.read(userProvider.notifier).updateUser(
-          name: 'みかど',
-          school: UsersSchoolModel(
-              id: 1,
-              parentId: 1,
-              name: '巴中学校',
-              schoolYear: 1,
-              classification: 1,
-              lunchBlock: 1
-          )
-      );
-
-      await ref.read(userProvider.notifier).getUser();
-      if (ref.read(userProvider.notifier).isExistUser()) {
+    final bool _isExistUser = await ref.read(userProvider.notifier).getUser();
+    if (_isExistUser) {
+      try {
         yield* ref.read(menusProvider.notifier).initialMenus(ref.watch(userProvider).user);
-        // TODO: ホーム画面への遷移
-      } else {
-        // TODO: 新規登録画面への遷移
+      } catch (error) {
+        debugPrint(error.toString());
+        _showErrorDialog(context);
       }
-    } catch (error) {
-      debugPrint(error.toString());
-      _showErrorDialog(context);
     }
+    ref.read(routerProvider.notifier).handleFromSplash(isExistUser: _isExistUser);
   }
 
   void _showErrorDialog(BuildContext context) {

--- a/lib/view/terms.dart
+++ b/lib/view/terms.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hakondate_v2/router/app_navigator_state_notifier.dart';
 
 import 'package:hakondate_v2/unit/design_unit.dart';
 import 'package:hakondate_v2/view_model/is_agreed_view_model.dart';
 
 class Terms extends ConsumerWidget {
-  void _handle() {}
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     bool _isAgreed = ref.watch(isAgreedProvider);
@@ -51,7 +50,7 @@ class Terms extends ConsumerWidget {
                       ),
                       shape: StadiumBorder()
                     ),
-                    onPressed: _isAgreed ? _handle : null,
+                    onPressed: _isAgreed ? ref.read(routerProvider.notifier).handleFromTerms : null,
                     child: Text('お子様の登録')
                   )
                 ],

--- a/lib/view_model/user_view_model.dart
+++ b/lib/view_model/user_view_model.dart
@@ -19,19 +19,19 @@ final userProvider = StateNotifierProvider<UserViewModel, UserState>((ref) => Us
 class UserViewModel extends StateNotifier<UserState> {
   UserViewModel() : super(UserState());
 
-  Future<void> getUser() async {
+  Future<bool> getUser() async {
     try {
       final File _userFile = await _getUserFile();
       final String _content = await _userFile.readAsString();
       UserModel _user = UserModel.fromJson(json.decode(_content));
       state = state.copyWith(user: _user);
+      return true;
     } catch (error) {
       debugPrint('Either the user has not registered, or access to the user file has failed.');
       debugPrint(error.toString());
+      return false;
     }
   }
-
-  bool isExistUser() => state.user.name != null && state.user.school != null;
 
   Future<void> updateUser({String? name, UsersSchoolModel? school}) async {
     UserModel _user = state.user;


### PR DESCRIPTION
遷移の実装．今回はNavigator2.0なるものがあったので宣言的な遷移の実装を行った．  
実装内容
- Material.routerの実装
    - AppRouterDelegateの実装
    - ListRouteInformationParserの実装
    - Navigatorの設定
- AppNavigatorStateの実装
- AppNavigatorStateNotifierの実装
- AppNavigatorStateNotifierを用いたProviderの実装

各種遷移は用意したが，ネストした部分の実装は未着手