### PR TITLE
HOMENavigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,11 +16,11 @@ void main() {
 }
 
 class Hakondate extends StatelessWidget {
-  final _routeInformationParser = ListRouteInformationParser();
-  final _appRouterDelegate = AppRouterDelegate();
-
   @override
   Widget build(BuildContext context) {
+    final _routeInformationParser = ListRouteInformationParser();
+    final _appRouterDelegate = AppRouterDelegate();
+    final _backButtonDispatcher = RootBackButtonDispatcher();
     final ThemeData theme = ThemeData(
       fontFamily: 'MPLUSRounded1c',
       appBarTheme: AppBarTheme(
@@ -42,6 +42,7 @@ class Hakondate extends StatelessWidget {
         ),
         routeInformationParser: _routeInformationParser,
         routerDelegate: _appRouterDelegate,
+        backButtonDispatcher: _backButtonDispatcher,
         debugShowCheckedModeBanner: false,
       ),
     );

--- a/lib/router/app_navigator_state_notifier.dart
+++ b/lib/router/app_navigator_state_notifier.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hakondate_v2/state/navigator/app_navigator_state.dart';
 
-final routerProvider =
+final appRouterProvider =
     StateNotifierProvider<AppNavigatorStateNotifier, AppNavigatorState>(
         (ref) => AppNavigatorStateNotifier());
 

--- a/lib/router/app_router_delegate.dart
+++ b/lib/router/app_router_delegate.dart
@@ -3,22 +3,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hakondate_v2/router/app_navigator_state_notifier.dart';
+import 'package:hakondate_v2/view/home/app_bottom_navigation_bar.dart';
 import 'package:hakondate_v2/view/signup/signup.dart';
 import 'package:hakondate_v2/view/splash/splash.dart';
 import 'package:hakondate_v2/view/terms/terms.dart';
 
 class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavigatorRouterDelegateMixin {
-  AppRouterDelegate();
-
   @override
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
   bool _handlePopPage(Route<dynamic> route, dynamic result, WidgetRef ref) {
     if (!route.didPop(result)) return false;
 
-    final _router = ref.watch(routerProvider);
+    final _router = ref.watch(appRouterProvider);
     if (_router.isShowSetting || _router.isShowAboutUs || _router.isShowHelp)
-      ref.read(routerProvider.notifier).handleToHome();
+      ref.read(appRouterProvider.notifier).handleToHome();
 
     return true;
   }
@@ -27,7 +26,8 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
   Widget build(BuildContext context) {
     return Consumer(
       builder: (BuildContext context, WidgetRef ref, _) {
-        final _router = ref.watch(routerProvider);
+        final _router = ref.watch(appRouterProvider);
+
         return Navigator(
           key: navigatorKey,
           onPopPage: (Route<dynamic> route, dynamic result) =>
@@ -49,10 +49,9 @@ class AppRouterDelegate extends RouterDelegate<List<RouteSettings>> with PopNavi
                 child: Signup(),
               ),
             ] else ...[
-              // TODO: HOME内のNavigatorの実装
               MaterialPage(
-                key: ValueKey('home'),
-                child: Scaffold(),
+                key: ValueKey('main'),
+                child: AppBottomNavigationBar(),
               ),
               if (_router.isShowSetting)
                 MaterialPage(

--- a/lib/router/home_navigation_state_notifier.dart
+++ b/lib/router/home_navigation_state_notifier.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hakondate_v2/state/navigator/home_navigator_state.dart';
+
+final homeRouterProvider =
+    StateNotifierProvider<HomeNavigationStateNotifier, HomeNavigatorState>(
+        (ref) => HomeNavigationStateNotifier());
+
+class HomeNavigationStateNotifier extends StateNotifier<HomeNavigatorState> {
+  HomeNavigationStateNotifier() : super(HomeNavigatorState());
+
+  void initialize(int schoolId) {
+    final DateTime _today = DateTime.now();
+    final _todayMenuId = _today.year * 1000000
+        + _today.month * 10000
+        + _today.day * 100
+        + schoolId;
+    state = state.copyWith(todayMenuId: _todayMenuId);
+  }
+
+  void handleFromHome({bool isShowMenuList = false, int? menuId, int? dishId}) =>
+      state = state.copyWith(
+        isShowMenuList: isShowMenuList,
+        selectedMenuId: menuId ?? state.selectedMenuId,
+        selectedDishId: dishId,
+      );
+
+  void handleFromMenuList({int? menuId}) => state = state.copyWith(
+    isShowMenuList: false,
+    selectedMenuId: menuId ?? state.todayMenuId,
+  );
+
+  void handleFromDish({int? dishId}) => state = state.copyWith(selectedDishId: dishId);
+}

--- a/lib/router/home_router_delegate.dart
+++ b/lib/router/home_router_delegate.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hakondate_v2/router/home_navigation_state_notifier.dart';
+
+class HomeRouterDelegate extends RouterDelegate<List<RouteSettings>>
+    with PopNavigatorRouterDelegateMixin {
+  @override
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+  bool _handlePopPage(Route<dynamic> route, dynamic result, WidgetRef ref) {
+    final store = ref.watch(homeRouterProvider);
+
+    if (!route.didPop(result)) {
+      if (store.selectedMenuId != store.todayMenuId)
+        ref.read(homeRouterProvider.notifier)
+            .handleFromHome(menuId: store.todayMenuId);
+
+      return false;
+    }
+
+    if (store.selectedDishId != null)
+      ref.read(homeRouterProvider.notifier).handleFromDish();
+    else if (store.isShowMenuList)
+      ref.read(homeRouterProvider.notifier).handleFromMenuList();
+
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer(
+      builder: (BuildContext context, WidgetRef ref, _) {
+        final _router = ref.watch(homeRouterProvider);
+
+        return Navigator(
+          key: navigatorKey,
+          onPopPage:(Route<dynamic> route, dynamic result) =>
+              _handlePopPage(route, result, ref),
+          pages: [
+            MaterialPage(
+              key: ValueKey('home'),
+              child: Scaffold(),
+            ),
+            if (_router.isShowMenuList)
+              MaterialPage(
+                key: ValueKey('menuList'),
+                child: Scaffold(),
+              ),
+            if (_router.selectedDishId != null)
+              MaterialPage(
+                key: ValueKey('dish${_router.selectedDishId.toString()}'),
+                child: Scaffold(),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  void addListener(VoidCallback listener) {}
+  @override
+  void removeListener(VoidCallback listener) {}
+  @override
+  Future<void> setNewRoutePath(List<RouteSettings> configuration) async {}
+}
+
+class HomeListRouteInformationParser extends RouteInformationParser<List<RouteSettings>> {
+  @override
+  Future<List<RouteSettings>> parseRouteInformation(RouteInformation routeInformation) async => [];
+}

--- a/lib/state/navigator/app_navigator_state.dart
+++ b/lib/state/navigator/app_navigator_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'app_navigator_state.freezed.dart';
@@ -14,10 +15,3 @@ class AppNavigatorState with _$AppNavigatorState {
     @Default(false) bool isShowAboutUs,
   }) = _AppNavigatorState;
 }
-
-// Home内の遷移で少なくても必要になるやつら
-// @Default(false) bool isShowMenuList,
-// int? selectedMenuId,
-// int? selectedDishId,
-// int? selectedPopularRecipeId,
-// int? selectedMonthlyOriginId,

--- a/lib/state/navigator/home_navigator_state.dart
+++ b/lib/state/navigator/home_navigator_state.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_navigator_state.freezed.dart';
+
+@freezed
+class HomeNavigatorState with _$HomeNavigatorState {
+  const factory HomeNavigatorState({
+    @Default(-1) int todayMenuId,
+    @Default(-1) int selectedMenuId,    // -1: データなし, 0: 給食が休み
+    @Default(false) bool isShowMenuList,
+    int? selectedDishId,
+  }) = _HomeNavigatorState;
+}

--- a/lib/state/navigator/home_navigator_state.freezed.dart
+++ b/lib/state/navigator/home_navigator_state.freezed.dart
@@ -1,0 +1,241 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
+
+part of 'home_navigator_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$HomeNavigatorStateTearOff {
+  const _$HomeNavigatorStateTearOff();
+
+  _HomeNavigatorState call(
+      {int todayMenuId = -1,
+      int selectedMenuId = -1,
+      bool isShowMenuList = false,
+      int? selectedDishId}) {
+    return _HomeNavigatorState(
+      todayMenuId: todayMenuId,
+      selectedMenuId: selectedMenuId,
+      isShowMenuList: isShowMenuList,
+      selectedDishId: selectedDishId,
+    );
+  }
+}
+
+/// @nodoc
+const $HomeNavigatorState = _$HomeNavigatorStateTearOff();
+
+/// @nodoc
+mixin _$HomeNavigatorState {
+  int get todayMenuId => throw _privateConstructorUsedError;
+  int get selectedMenuId =>
+      throw _privateConstructorUsedError; // -1: データなし, 0: 給食が休み
+  bool get isShowMenuList => throw _privateConstructorUsedError;
+  int? get selectedDishId => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $HomeNavigatorStateCopyWith<HomeNavigatorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HomeNavigatorStateCopyWith<$Res> {
+  factory $HomeNavigatorStateCopyWith(
+          HomeNavigatorState value, $Res Function(HomeNavigatorState) then) =
+      _$HomeNavigatorStateCopyWithImpl<$Res>;
+  $Res call(
+      {int todayMenuId,
+      int selectedMenuId,
+      bool isShowMenuList,
+      int? selectedDishId});
+}
+
+/// @nodoc
+class _$HomeNavigatorStateCopyWithImpl<$Res>
+    implements $HomeNavigatorStateCopyWith<$Res> {
+  _$HomeNavigatorStateCopyWithImpl(this._value, this._then);
+
+  final HomeNavigatorState _value;
+  // ignore: unused_field
+  final $Res Function(HomeNavigatorState) _then;
+
+  @override
+  $Res call({
+    Object? todayMenuId = freezed,
+    Object? selectedMenuId = freezed,
+    Object? isShowMenuList = freezed,
+    Object? selectedDishId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      todayMenuId: todayMenuId == freezed
+          ? _value.todayMenuId
+          : todayMenuId // ignore: cast_nullable_to_non_nullable
+              as int,
+      selectedMenuId: selectedMenuId == freezed
+          ? _value.selectedMenuId
+          : selectedMenuId // ignore: cast_nullable_to_non_nullable
+              as int,
+      isShowMenuList: isShowMenuList == freezed
+          ? _value.isShowMenuList
+          : isShowMenuList // ignore: cast_nullable_to_non_nullable
+              as bool,
+      selectedDishId: selectedDishId == freezed
+          ? _value.selectedDishId
+          : selectedDishId // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$HomeNavigatorStateCopyWith<$Res>
+    implements $HomeNavigatorStateCopyWith<$Res> {
+  factory _$HomeNavigatorStateCopyWith(
+          _HomeNavigatorState value, $Res Function(_HomeNavigatorState) then) =
+      __$HomeNavigatorStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {int todayMenuId,
+      int selectedMenuId,
+      bool isShowMenuList,
+      int? selectedDishId});
+}
+
+/// @nodoc
+class __$HomeNavigatorStateCopyWithImpl<$Res>
+    extends _$HomeNavigatorStateCopyWithImpl<$Res>
+    implements _$HomeNavigatorStateCopyWith<$Res> {
+  __$HomeNavigatorStateCopyWithImpl(
+      _HomeNavigatorState _value, $Res Function(_HomeNavigatorState) _then)
+      : super(_value, (v) => _then(v as _HomeNavigatorState));
+
+  @override
+  _HomeNavigatorState get _value => super._value as _HomeNavigatorState;
+
+  @override
+  $Res call({
+    Object? todayMenuId = freezed,
+    Object? selectedMenuId = freezed,
+    Object? isShowMenuList = freezed,
+    Object? selectedDishId = freezed,
+  }) {
+    return _then(_HomeNavigatorState(
+      todayMenuId: todayMenuId == freezed
+          ? _value.todayMenuId
+          : todayMenuId // ignore: cast_nullable_to_non_nullable
+              as int,
+      selectedMenuId: selectedMenuId == freezed
+          ? _value.selectedMenuId
+          : selectedMenuId // ignore: cast_nullable_to_non_nullable
+              as int,
+      isShowMenuList: isShowMenuList == freezed
+          ? _value.isShowMenuList
+          : isShowMenuList // ignore: cast_nullable_to_non_nullable
+              as bool,
+      selectedDishId: selectedDishId == freezed
+          ? _value.selectedDishId
+          : selectedDishId // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_HomeNavigatorState
+    with DiagnosticableTreeMixin
+    implements _HomeNavigatorState {
+  const _$_HomeNavigatorState(
+      {this.todayMenuId = -1,
+      this.selectedMenuId = -1,
+      this.isShowMenuList = false,
+      this.selectedDishId});
+
+  @JsonKey(defaultValue: -1)
+  @override
+  final int todayMenuId;
+  @JsonKey(defaultValue: -1)
+  @override
+  final int selectedMenuId;
+  @JsonKey(defaultValue: false)
+  @override // -1: データなし, 0: 給食が休み
+  final bool isShowMenuList;
+  @override
+  final int? selectedDishId;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'HomeNavigatorState(todayMenuId: $todayMenuId, selectedMenuId: $selectedMenuId, isShowMenuList: $isShowMenuList, selectedDishId: $selectedDishId)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'HomeNavigatorState'))
+      ..add(DiagnosticsProperty('todayMenuId', todayMenuId))
+      ..add(DiagnosticsProperty('selectedMenuId', selectedMenuId))
+      ..add(DiagnosticsProperty('isShowMenuList', isShowMenuList))
+      ..add(DiagnosticsProperty('selectedDishId', selectedDishId));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _HomeNavigatorState &&
+            (identical(other.todayMenuId, todayMenuId) ||
+                const DeepCollectionEquality()
+                    .equals(other.todayMenuId, todayMenuId)) &&
+            (identical(other.selectedMenuId, selectedMenuId) ||
+                const DeepCollectionEquality()
+                    .equals(other.selectedMenuId, selectedMenuId)) &&
+            (identical(other.isShowMenuList, isShowMenuList) ||
+                const DeepCollectionEquality()
+                    .equals(other.isShowMenuList, isShowMenuList)) &&
+            (identical(other.selectedDishId, selectedDishId) ||
+                const DeepCollectionEquality()
+                    .equals(other.selectedDishId, selectedDishId)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(todayMenuId) ^
+      const DeepCollectionEquality().hash(selectedMenuId) ^
+      const DeepCollectionEquality().hash(isShowMenuList) ^
+      const DeepCollectionEquality().hash(selectedDishId);
+
+  @JsonKey(ignore: true)
+  @override
+  _$HomeNavigatorStateCopyWith<_HomeNavigatorState> get copyWith =>
+      __$HomeNavigatorStateCopyWithImpl<_HomeNavigatorState>(this, _$identity);
+}
+
+abstract class _HomeNavigatorState implements HomeNavigatorState {
+  const factory _HomeNavigatorState(
+      {int todayMenuId,
+      int selectedMenuId,
+      bool isShowMenuList,
+      int? selectedDishId}) = _$_HomeNavigatorState;
+
+  @override
+  int get todayMenuId => throw _privateConstructorUsedError;
+  @override
+  int get selectedMenuId => throw _privateConstructorUsedError;
+  @override // -1: データなし, 0: 給食が休み
+  bool get isShowMenuList => throw _privateConstructorUsedError;
+  @override
+  int? get selectedDishId => throw _privateConstructorUsedError;
+  @override
+  @JsonKey(ignore: true)
+  _$HomeNavigatorStateCopyWith<_HomeNavigatorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/unit/size.dart
+++ b/lib/unit/size.dart
@@ -24,3 +24,8 @@ class PaddingSize {
   static const double buttonVertical = 5.0;     // ボタンの水平方向の基本マージン
   static const double buttonHorizontal = 25.0;  // ボタンの垂直方向の基本マージン
 }
+
+class IconSize {
+  static const double help = 20.0;              // ヘルプ用
+  static const double navigationItem = 30.0;    // ボトムバー用
+}

--- a/lib/view/home/app_bottom_navigation_bar.dart
+++ b/lib/view/home/app_bottom_navigation_bar.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hakondate_v2/router/home_router_delegate.dart';
+import 'package:hakondate_v2/unit/size.dart';
+
+class AppBottomNavigationBar extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final _backButtonDispatcher = ChildBackButtonDispatcher(Router.of(context).backButtonDispatcher!);
+
+    return WillPopScope(
+      onWillPop: () => Future<bool>.value(true),
+      child: CupertinoTabScaffold(
+        tabBar: CupertinoTabBar(
+          activeColor: Theme.of(context).colorScheme.secondary,
+          items: [
+            BottomNavigationBarItem(
+              icon: Icon(
+                Icons.local_dining,
+                size: IconSize.navigationItem,
+              ),
+              label: 'こんだて',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                Icons.restaurant,
+                size: IconSize.navigationItem,
+              ),
+              label: 'レシピ',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                Icons.book,
+                size: IconSize.navigationItem,
+              ),
+              label: 'ずかん',
+            ),
+          ],
+        ),
+        tabBuilder: (BuildContext context, int index) {
+          switch (index) {
+            case 0:
+              return CupertinoTabView(
+                builder: (BuildContext context) {
+                  final _homeRouteInformationParser = HomeListRouteInformationParser();
+                  final _homeRouterDelegate = HomeRouterDelegate();
+
+                  return Router(
+                    routeInformationParser: _homeRouteInformationParser,
+                    routerDelegate: _homeRouterDelegate,
+                    backButtonDispatcher: _backButtonDispatcher,
+                  );
+                },
+              );
+            case 1:
+              return CupertinoTabView(
+                builder: (BuildContext context) {
+                  return Scaffold();
+                },
+              );
+            case 2:
+              return CupertinoTabView(
+                builder: (BuildContext context) {
+                  return Scaffold();
+                },
+              );
+          }
+          return Container();
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/signup/loading_dialog.dart
+++ b/lib/view/signup/loading_dialog.dart
@@ -75,7 +75,7 @@ class LoadingDialog {
           .initialize(ref.watch(userProvider).currentUser!.schoolId)) {
         yield status;
       }
-      ref.read(routerProvider.notifier).handleFromSignup();
+      ref.read(appRouterProvider.notifier).handleFromSignup();
     } catch (error) {
       debugPrint(error.toString());
 
@@ -103,7 +103,7 @@ class LoadingDialog {
                   final DateTime _loadingDay = DateTime(DateTime.now().year, DateTime.now().month);
                   await ref.read(menusProvider.notifier).getLocalMenus(_loadingDay, ref.watch(userProvider).currentUser!.schoolId);
                   ref.read(loadingProvider.notifier).popErrorDialog();
-                  ref.read(routerProvider.notifier).handleFromSignup();
+                  ref.read(appRouterProvider.notifier).handleFromSignup();
                 },
               ),
               CupertinoDialogAction(
@@ -111,7 +111,7 @@ class LoadingDialog {
                 child: Text('リトライ'),
                 onPressed: () {
                   ref.read(loadingProvider.notifier).popErrorDialog();
-                  ref.read(routerProvider.notifier).handleReload();
+                  ref.read(appRouterProvider.notifier).handleReload();
                   Navigator.of(context).pop();
                 },
               )

--- a/lib/view/signup/signup.dart
+++ b/lib/view/signup/signup.dart
@@ -107,7 +107,7 @@ class Signup extends ConsumerWidget {
               ),
               IconButton(
                 icon: Icon(Icons.help),
-                iconSize: 20,
+                iconSize: IconSize.help,
                 color: Theme.of(context).primaryIconTheme.color,
                 onPressed: () => HelpDialog(
                   context,
@@ -159,7 +159,7 @@ class Signup extends ConsumerWidget {
               ),
               IconButton(
                 icon: Icon(Icons.help),
-                iconSize: 20,
+                iconSize: IconSize.help,
                 color: Theme.of(context).primaryIconTheme.color,
                 onPressed: () => HelpDialog(
                   context,

--- a/lib/view/splash/splash.dart
+++ b/lib/view/splash/splash.dart
@@ -22,7 +22,7 @@ class Splash extends ConsumerWidget {
           yield status;
         }
       }
-      ref.read(routerProvider.notifier).handleFromSplash(toTerms: !_isSignedUp);
+      ref.read(appRouterProvider.notifier).handleFromSplash(toTerms: !_isSignedUp);
     } catch (error) {
       debugPrint(error.toString());
 
@@ -55,7 +55,7 @@ class Splash extends ConsumerWidget {
                   final DateTime _loadingDay = DateTime(DateTime.now().year, DateTime.now().month);
                   await ref.read(menusProvider.notifier).getLocalMenus(_loadingDay, ref.watch(userProvider).currentUser!.schoolId);
                   ref.read(loadingProvider.notifier).popErrorDialog();
-                  ref.read(routerProvider.notifier).handleFromSplash();
+                  ref.read(appRouterProvider.notifier).handleFromSplash();
                 },
               ),
               CupertinoDialogAction(
@@ -63,7 +63,7 @@ class Splash extends ConsumerWidget {
                 child: Text('リトライ'),
                 onPressed: () {
                   ref.read(loadingProvider.notifier).popErrorDialog();
-                  ref.read(routerProvider.notifier).handleReload();
+                  ref.read(appRouterProvider.notifier).handleReload();
                   Navigator.of(context).pop();
                 },
               )

--- a/lib/view/terms/terms.dart
+++ b/lib/view/terms/terms.dart
@@ -51,7 +51,7 @@ class Terms extends ConsumerWidget {
                       shape: StadiumBorder()
                     ),
                     child: Text('はじめる'),
-                    onPressed: store.isAgree ? ref.read(routerProvider.notifier).handleFromTerms : null,
+                    onPressed: store.isAgree ? ref.read(appRouterProvider.notifier).handleFromTerms : null,
                   )
                 ],
               ),


### PR DESCRIPTION
おおよそIssue通りの実装をした．画面の遷移モデルを変更した．

今までは，別日のメニューは新しいページを用意していたが，今回からは同ページ内で内容を切り替える方式にした．
それによって，カレンダー画面に行かずとも近日の献立に飛べるような実装が自然にできる．

新しいメイン画面の実装イメージは以下の写真のタブ部分に近いものをイメージしている．
![IMG_C0AA85AE8219-1](https://user-images.githubusercontent.com/43740965/135799543-e2779578-4c02-4a84-b5c3-3b108241f56a.jpeg)
