### PR TITLE
vscodeの自動フォーマットの修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "dart.flutterSdkPath": ".fvm/flutter_sdk",
+  "dart.lineLength": 140,
   "search.exclude": {
     "**/.fvm": true,
     "**/*.g.dart": true,


### PR DESCRIPTION
**Issueリンク**
<!-- #1 とかでリンク作れるから取り組んだ課題をリンクさせる -->
vscodeの自動フォーマットで80文字で改行されてしまう問題があったのでそれに対する修正
dartプラグインのlineLengthを変更しなきゃいけないみたいです（デフォルトではdartプラグインのフォーマッターが優先されるっぽいです）

**実装したこと**
<!--
実装したことを追記していく
例）
- [x] 献立モデル（MenuModel）の定義
- [x] 今日の献立データをDBから取得するViewModelの定義
-->
- [x] vscodeのフォーマッターの設定の修正 (140文字に)

**実装しなかったこと**

- 特になし

**スクリーンショット**
<!-- UIに関する実装の場合はスクショを貼る -->

**補足事項**

- 特になし

**チェックリスト**
<!-- レビューをしてもらう前に自身で確認を行う -->
- [x] 提出予定のファイルを確認し不要な変更やファイルが混入していないかを確認した
- [x] 環境変数や秘匿情報を扱うファイルの変更を適切に行なった（または変更していない）
    - [ ] 管理情報の更新を行なった
    - [ ] 該当ファイルを保存場所にアップロードした
