### PR TITLE
食材に精白米が混入する問題を解決

### DIFF
--- a/lib/repository/local/sqlite/menus/menus_local_repository.dart
+++ b/lib/repository/local/sqlite/menus/menus_local_repository.dart
@@ -155,7 +155,7 @@ class MenusLocalRepository extends MenusLocalRepositoryAPI {
         conflictSchema.dietaryFiber != companion.dietaryFiber.value ||
         conflictSchema.salt != companion.salt.value ||
         conflictSchema.origin != companion.origin.value) {
-      return (_db.update(_db.foodstuffsTable)
+      await (_db.update(_db.foodstuffsTable)
             ..where(
               ($FoodstuffsTableTable t) =>
                   t.name.equals(companion.name.value) &
@@ -184,6 +184,8 @@ class MenusLocalRepository extends MenusLocalRepositoryAPI {
           origin: companion.origin,
         ),
       );
+
+      return conflictSchema.id;
     }
 
     return conflictSchema.id;


### PR DESCRIPTION
**Issueリンク**
<!-- #1 とかでリンク作れるから取り組んだ課題をリンクさせる -->
#226

**実装したこと**
<!--
実装したことを追記していく
例）
- [x] 献立モデル（MenuModel）の定義
- [x] 今日の献立データをDBから取得するViewModelの定義
-->
- [x] 食材に精白米が混入する問題を解決

driftのwrite()関数は，変更した行数を返す．
しかし，idを返すと誤認した実装になっていた．
そのため，そこを修正した．

**実装しなかったこと**

- 特になし

**スクリーンショット**
<!-- UIに関する実装の場合はスクショを貼る -->
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-22 at 21 42 33](https://github.com/user-attachments/assets/46b4098e-9ace-43d0-a5db-43c91fb6525f)

**補足事項**

- 特になし

**チェックリスト**
<!-- レビューをしてもらう前に自身で確認を行う -->
- [x] 提出予定のファイルを確認し不要な変更やファイルが混入していないかを確認した
- [x] 環境変数や秘匿情報を扱うファイルの変更を適切に行なった（または変更していない）
    - [x] 管理情報の更新を行なった
    - [x] 該当ファイルを保存場所にアップロードした
