### PR TITLE
ごはんとコッペパンで複数の食材が表示される問題の対応

### DIFF
--- a/lib/repository/local/sqlite/menus/menus_local_repository.dart
+++ b/lib/repository/local/sqlite/menus/menus_local_repository.dart
@@ -88,11 +88,12 @@ class MenusLocalRepository extends MenusLocalRepositoryAPI {
     if (conflictSchema == null) {
       dishId = await _db.into(_db.dishesTable).insert(companion);
     } else if (conflictSchema.category != companion.category.value) {
-      dishId = await (_db.update(_db.dishesTable)
+      await (_db.update(_db.dishesTable)
             ..where(
               ($DishesTableTable t) => t.name.equals(companion.name.value),
             ))
           .write(DishesTableCompanion(category: companion.category));
+      dishId = conflictSchema.id;
     } else {
       dishId = conflictSchema.id;
     }

--- a/lib/view_model/single_page/daily/daily_view_model.dart
+++ b/lib/view_model/single_page/daily/daily_view_model.dart
@@ -1,3 +1,5 @@
+import 'package:hakondate/model/foodstuff/foodstuff_model.dart';
+import 'package:hakondate/view_model/multi_page/user/user_view_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:hakondate/model/dish/dish_model.dart';
@@ -75,7 +77,36 @@ class DailyViewModel extends _$DailyViewModel {
 
   void selectDish(DishModel dish) {
     state.whenData((DailyState data) {
-      state = AsyncData<DailyState>(data.copyWith(selectedDish: dish));
+      // 桔梗小と巴中で同じ料理の対して異なる食材を使う場合の対応
+      // 現在把握している問題はごはんとコッペパンのみ
+      // 将来的にはDBを修正して対応する
+      DishModel? newDish;
+      if (dish.name == 'ごはん' || dish.name == 'ごはん【茶碗なし】') {
+        if (dish.foodstuffs.length == 2) {
+          final int? currentSchool = ref.watch(userViewModelProvider).currentUser?.schoolId;
+          final List<FoodstuffModel> newFoodstuffs = dish.foodstuffs.where((FoodstuffModel foodstuff) {
+            if (currentSchool == 1 || currentSchool == 2 || currentSchool == 3) {
+              return foodstuff.name == '精白米100';
+            } else {
+              return foodstuff.name == '精白米70';
+            }
+          }).toList();
+          newDish = dish.copyWith(foodstuffs: newFoodstuffs);
+        }
+      } else if (dish.name == 'コッペパン') {
+        if (dish.foodstuffs.length == 2) {
+          final int? currentSchool = ref.watch(userViewModelProvider).currentUser?.schoolId;
+          final List<FoodstuffModel> newFoodstuffs = dish.foodstuffs.where((FoodstuffModel foodstuff) {
+            if (currentSchool == 1 || currentSchool == 2 || currentSchool == 3) {
+              return foodstuff.name == 'コッペパン65';
+            } else {
+              return foodstuff.name == 'コッペパン50';
+            }
+          }).toList();
+          newDish = dish.copyWith(foodstuffs: newFoodstuffs);
+        }
+      }
+      state = AsyncData<DailyState>(data.copyWith(selectedDish: newDish ?? dish));
     });
   }
 }

--- a/lib/view_model/single_page/daily/daily_view_model.dart
+++ b/lib/view_model/single_page/daily/daily_view_model.dart
@@ -1,13 +1,13 @@
-import 'package:hakondate/model/foodstuff/foodstuff_model.dart';
-import 'package:hakondate/view_model/multi_page/user/user_view_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:hakondate/model/dish/dish_model.dart';
+import 'package:hakondate/model/foodstuff/foodstuff_model.dart';
 import 'package:hakondate/model/menu/menu_model.dart';
 import 'package:hakondate/repository/local/sqlite/menus/menus_local_repository.dart';
 import 'package:hakondate/state/daily/daily_state.dart';
 import 'package:hakondate/util/analytics_controller/analytics_controller.dart';
 import 'package:hakondate/util/environment.dart';
+import 'package:hakondate/view_model/multi_page/user/user_view_model.dart';
 
 part 'daily_view_model.g.dart';
 

--- a/lib/view_model/single_page/daily/daily_view_model.g.dart
+++ b/lib/view_model/single_page/daily/daily_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'daily_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dailyViewModelHash() => r'3bc464a06d3713adfa5cb25c723e0baecc51035d';
+String _$dailyViewModelHash() => r'a415ff98fb249adeb62aea33604b99b512bc27ee';
 
 /// See also [DailyViewModel].
 @ProviderFor(DailyViewModel)


### PR DESCRIPTION
**Issueリンク**
<!-- #1 とかでリンク作れるから取り組んだ課題をリンクさせる -->

**実装したこと**
<!--
実装したことを追記していく
例）
- [x] 献立モデル（MenuModel）の定義
- [x] 今日の献立データをDBから取得するViewModelの定義
-->
- [x] ごはんに牛乳が混在するバグの修正
- [x] 桔梗小と巴中で同じ料理の対して異なる食材を使う場合の対応
  - [x] ごはんとごはん【茶碗なし】において，精白米100と精白米70が表示される
  - [x] コッペパンにおいて，コッペパン65とコッペパン50が表示される

**実装しなかったこと**

- 根本対応
- 他の料理にもあるかの調査

**スクリーンショット**
<!-- UIに関する実装の場合はスクショを貼る -->

**補足事項**

- 特になし

**チェックリスト**
<!-- レビューをしてもらう前に自身で確認を行う -->
- [x] 提出予定のファイルを確認し不要な変更やファイルが混入していないかを確認した
- [x] 環境変数や秘匿情報を扱うファイルの変更を適切に行なった（または変更していない）
    - [x] 管理情報の更新を行なった
    - [x] 該当ファイルを保存場所にアップロードした
